### PR TITLE
Add S3 data fetching to YOLO training workflow

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -1,12 +1,10 @@
 train: dataset/images/train
-val:   dataset/images/val
-test:  dataset/images/test
+val: dataset/images/val
+test: dataset/images/test
 
-# nombre de classes
+# Number of classes
+nc: 5
 
-nc: 2
-
-#Nom des classes
-
-names: ['answer', 'question']
+# Class names
+names: ['schematic', 'table', 'qcm', 'preamble', 'question_year']
 

--- a/fetch_s3_dataset.py
+++ b/fetch_s3_dataset.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Download images and annotations from S3 metadata.
+
+Each PNG object stored in the provided S3 buckets is expected to carry
+YOLO-style bounding boxes inside custom metadata headers named
+``x-amz-meta-<class>`` where ``<class>`` is one of the supported class
+names. The header value should be a base64 encoded string containing one
+or more lines in the form ``<class_id> x_center y_center width height``
+(normalized coordinates) or just ``x_center y_center width height``.
+
+The script downloads the PNG file to an ``images/`` directory and writes
+its corresponding label file to ``labels/``.
+
+Example usage:
+    python fetch_s3_dataset.py my-bucket-1 my-bucket-2 --prefix data/
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+from typing import Iterable
+
+import boto3
+
+CLASSES = ["schematic", "table", "qcm", "preamble", "question_year"]
+CLASS_TO_ID = {name: i for i, name in enumerate(CLASSES)}
+
+
+def _write_label(lines: Iterable[str], path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def _process_object(s3, bucket: str, key: str, img_dir: str, lbl_dir: str) -> None:
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    body = obj["Body"].read()
+    os.makedirs(img_dir, exist_ok=True)
+    img_name = os.path.basename(key)
+    img_path = os.path.join(img_dir, img_name)
+    with open(img_path, "wb") as f:
+        f.write(body)
+
+    label_lines = []
+    metadata = obj.get("Metadata", {})
+    for cls_name, cls_id in CLASS_TO_ID.items():
+        if cls_name in metadata:
+            try:
+                decoded = base64.b64decode(metadata[cls_name]).decode().strip().splitlines()
+            except Exception:
+                continue
+            for line in decoded:
+                parts = line.strip().split()
+                if not parts:
+                    continue
+                # Ignore provided class id if present; use cls_id instead
+                if len(parts) == 5 and parts[0].isdigit():
+                    parts = parts[1:]
+                if len(parts) == 4:
+                    label_lines.append(f"{cls_id} {' '.join(parts)}")
+    lbl_name = os.path.splitext(img_name)[0] + ".txt"
+    lbl_path = os.path.join(lbl_dir, lbl_name)
+    _write_label(label_lines, lbl_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("buckets", nargs="+", help="S3 buckets to scan")
+    parser.add_argument(
+        "--prefix", default="", help="Optional prefix inside each bucket")
+    parser.add_argument(
+        "--images-dir", default="images", help="Directory for downloaded images")
+    parser.add_argument(
+        "--labels-dir", default="labels", help="Directory for generated labels")
+    args = parser.parse_args()
+
+    s3 = boto3.client("s3")
+    for bucket in args.buckets:
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=args.prefix):
+            for item in page.get("Contents", []):
+                key = item["Key"]
+                if key.lower().endswith(".png"):
+                    _process_object(s3, bucket, key, args.images_dir, args.labels_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/mastermind.py
+++ b/mastermind.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Orchestrate YOLOv8 training using images stored across multiple S3 buckets.
+
+Running ``python mastermind.py`` will:
+  1. Download all PNG images and their YOLO labels encoded in S3 object
+     metadata from a predefined list of buckets.
+  2. Split the gathered data into train/val/test subsets.
+  3. Launch a YOLOv8 training run on the prepared dataset.
+
+The script assumes AWS credentials with ``s3:GetObject`` and
+``s3:ListBucket`` permissions are configured in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from ultralytics import YOLO
+
+# Buckets storing the training images.
+BUCKETS = [
+    "acc-amiens",
+    "acc-bobigny",
+    "acc-bordeaux",
+    "acc-dijon",
+    "acc-lille",
+    "acc-marseille",
+    "acc-montpellier",
+    "acc-saclay",
+    "acc-sorbonne",
+    "acc-udp",
+    "acc-upec",
+    "acc-uvsq",
+    "actu-bobigny",
+    "actu-sorbonne",
+    "actu-upc",
+    "fiches-amiens",
+    "fiches-bobigny",
+    "fiches-bordeaux",
+    "fiches-dijon",
+    "fiches-lille",
+    "fiches-marseille",
+    "fiches-montpellier",
+    "fiches-saclay",
+    "fiches-sorbonne",
+    "fiches-udp",
+    "fiches-upec",
+    "fiches-uvsq",
+]
+
+# Ensure the AWS client knows which region to hit if none is configured.
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-north-1")
+
+
+def fetch_from_s3() -> None:
+    """Download images and labels for all buckets using ``fetch_s3_dataset.py``."""
+    cmd = ["python", "fetch_s3_dataset.py", *BUCKETS]
+    subprocess.run(cmd, check=True)
+
+
+def split_dataset() -> None:
+    """Split downloaded files into train/val/test directories."""
+    cmd = [
+        "python",
+        "split_dataset.py",
+        "-i",
+        "images",
+        "-l",
+        "labels",
+        "-o",
+        "dataset",
+        "-r",
+        "0.7",
+        "-v",
+        "0.2",
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def train_yolo() -> None:
+    """Train a YOLOv8 model on the prepared dataset."""
+    model = YOLO("yolo11n.pt")
+    model.train(
+        data="data.yaml",
+        epochs=200,
+        imgsz=640,
+        batch=16,
+        patience=15,
+        project="models",
+        name="exp_ex_corr",
+        tensorboard=True,
+    )
+
+
+def main() -> None:
+    fetch_from_s3()
+    split_dataset()
+    train_yolo()
+
+
+if __name__ == "__main__":
+    main()

--- a/train_yolo.sh
+++ b/train_yolo.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Train YOLOv8 model for exercise/correction detection.
+# Train YOLOv8 model for document element detection.
 # Usage: ./train_yolo.sh [epochs] [batch_size] [imgsz] [model] [data_cfg] [project_dir] [exp_name]
+
 EPOCHS=${1:-200}
 BATCH=${2:-16}
 IMGSZ=${3:-640}
@@ -8,7 +9,22 @@ MODEL=${4:-XXX.pt}
 DATA_CFG=${5:-data.yaml}
 PROJECT_DIR=${6:-models}
 EXP_NAME=${7:-exp_ex_corr}
-PATIENCE=${8:-15} 
+PATIENCE=${8:-15}
+
+# If S3 buckets are provided, fetch images and labels then create dataset split
+if [ -n "$S3_BUCKETS" ]; then
+    if [ -n "$S3_PREFIX" ]; then
+        python fetch_s3_dataset.py $S3_BUCKETS --prefix "$S3_PREFIX"
+    else
+        python fetch_s3_dataset.py $S3_BUCKETS
+    fi
+    python split_dataset.py \
+        -i images \
+        -l labels \
+        -o dataset \
+        -r 0.7 \
+        -v 0.2
+fi
 
 ultralytics train detect \
     model=$MODEL \


### PR DESCRIPTION
## Summary
- update dataset config for five document classes
- integrate optional S3 download and dataset split in training script
- add helper script to pull images/labels from S3 object metadata
- provide `mastermind.py` to orchestrate S3 fetching, dataset splitting, and training across predefined buckets

## Testing
- `python -m py_compile fetch_s3_dataset.py`
- `bash -n train_yolo.sh`
- `python fetch_s3_dataset.py --help`
- `python -m py_compile mastermind.py`


------
https://chatgpt.com/codex/tasks/task_e_688f3c729dbc832d95728278eef3c3c4