### PR TITLE
Filter S3 dataset to human-verified objects

### DIFF
--- a/train_yolo.sh
+++ b/train_yolo.sh
@@ -14,9 +14,9 @@ PATIENCE=${8:-15}
 # If S3 buckets are provided, fetch images and labels then create dataset split
 if [ -n "$S3_BUCKETS" ]; then
     if [ -n "$S3_PREFIX" ]; then
-        python fetch_s3_dataset.py $S3_BUCKETS --prefix "$S3_PREFIX"
+        python fetch_s3_dataset.py $S3_BUCKETS --prefix "$S3_PREFIX" --metadata-dir metadata
     else
-        python fetch_s3_dataset.py $S3_BUCKETS
+        python fetch_s3_dataset.py $S3_BUCKETS --metadata-dir metadata
     fi
     python split_dataset.py \
         -i images \


### PR DESCRIPTION
## Summary
- Only download S3 objects that have `x-amz-meta-human_verification=true`
- Save each object's metadata as JSON alongside images and labels
- Pass metadata output directory through the training script

## Testing
- `python -m py_compile fetch_s3_dataset.py`
- `bash -n train_yolo.sh`


------
https://chatgpt.com/codex/tasks/task_e_68906b6f40dc832daf716c86e14ef304