### PR TITLE
Filter S3 dataset to human-verified objects

### DIFF
--- a/train_yolo.py
+++ b/train_yolo.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Train a YOLOv8 model given a data config."""
+
+from __future__ import annotations
+
+import argparse
+from ultralytics import YOLO
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", required=True, help="Path to data.yaml")
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLOv8 model weights")
+    parser.add_argument("--epochs", type=int, default=200, help="Number of epochs")
+    parser.add_argument("--imgsz", type=int, default=640, help="Image size")
+    parser.add_argument("--batch", type=int, default=16, help="Batch size")
+    parser.add_argument("--patience", type=int, default=15, help="Early stopping patience")
+    parser.add_argument("--project", default="models", help="Ultralytics project directory")
+    parser.add_argument("--name", default="exp_ex_corr", help="Training run name")
+    args = parser.parse_args()
+
+    model = YOLO(args.model)
+    model.train(
+        data=args.data,
+        epochs=args.epochs,
+        imgsz=args.imgsz,
+        batch=args.batch,
+        patience=args.patience,
+        project=args.project,
+        name=args.name,
+        tensorboard=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/train_yolo.sh
+++ b/train_yolo.sh
@@ -14,9 +14,9 @@ PATIENCE=${8:-15}
 # If S3 buckets are provided, fetch images and labels then create dataset split
 if [ -n "$S3_BUCKETS" ]; then
     if [ -n "$S3_PREFIX" ]; then
-        python fetch_s3_dataset.py $S3_BUCKETS --prefix "$S3_PREFIX"
+        python fetch_s3_dataset.py $S3_BUCKETS --prefix "$S3_PREFIX" --metadata-dir metadata
     else
-        python fetch_s3_dataset.py $S3_BUCKETS
+        python fetch_s3_dataset.py $S3_BUCKETS --metadata-dir metadata
     fi
     python split_dataset.py \
         -i images \


### PR DESCRIPTION
## Summary
- Only download S3 objects that have `x-amz-meta-human_verification=true`
- Save each object's metadata as JSON alongside images and labels
- Pass metadata output directory through the training script
- Provide a Python `mastermind.py` to fetch from `fiches-udp` and `fiches-sorbonne`, split the dataset, generate `data.yaml`, and kick off training

## Testing
- `python -m py_compile fetch_s3_dataset.py split_dataset.py train_yolo.py mastermind.py`
- `bash -n train_yolo.sh`
- `python mastermind.py /tmp/ws-test` *(fails: botocore.exceptions.NoCredentialsError: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68906b6f40dc832daf716c86e14ef304