### PR TITLE
chore: add progress logs

### DIFF
--- a/fetch_s3_dataset.py
+++ b/fetch_s3_dataset.py
@@ -79,6 +79,7 @@ def _process_object(
     _write_label(label_lines, lbl_path)
     meta_path = os.path.join(meta_dir, os.path.splitext(img_name)[0] + ".json")
     _write_metadata(metadata, meta_path)
+    print(f"[+] Downloaded {bucket}/{key} -> {img_name}")
 
 
 def main() -> None:
@@ -96,6 +97,8 @@ def main() -> None:
 
     s3 = boto3.client("s3")
     for bucket in args.buckets:
+        print(f"[+] Scanning bucket {bucket}...")
+        count = 0
         paginator = s3.get_paginator("list_objects_v2")
         for page in paginator.paginate(Bucket=bucket, Prefix=args.prefix):
             for item in page.get("Contents", []):
@@ -109,6 +112,8 @@ def main() -> None:
                         args.labels_dir,
                         args.metadata_dir,
                     )
+                    count += 1
+        print(f"[+] Processed {count} objects from {bucket}")
 
 
 if __name__ == "__main__":

--- a/mastermind.py
+++ b/mastermind.py
@@ -18,6 +18,7 @@ function main() {
   }
   const workspaceDir = path.resolve(workspaceArg);
   fs.mkdirSync(workspaceDir, { recursive: true });
+  console.log(`[+] Workspace directory set to ${workspaceDir}`);
 
   // Ensure AWS region is set
   if (!process.env.AWS_DEFAULT_REGION) {
@@ -30,6 +31,7 @@ function main() {
   const datasetDir = path.join(workspaceDir, 'dataset');
 
   const fetchScript = path.join(__dirname, 'fetch_s3_dataset.py');
+  console.log('[+] Fetching dataset from S3...');
   run('python', [
     fetchScript,
     'fiches-udp',
@@ -40,6 +42,7 @@ function main() {
   ]);
 
   const splitScript = path.join(__dirname, 'split_dataset.py');
+  console.log('[+] Splitting dataset into train/val/test...');
   run('python', [
     splitScript,
     '-i', imagesDir,
@@ -50,6 +53,7 @@ function main() {
   ]);
 
   const dataYamlPath = path.join(workspaceDir, 'data.yaml');
+  console.log('[+] Writing data.yaml configuration...');
   const yamlContent = [
     `train: ${path.join(datasetDir, 'images/train')}`,
     `val: ${path.join(datasetDir, 'images/val')}`,
@@ -66,11 +70,13 @@ function main() {
 
   const trainScript = path.join(__dirname, 'train_yolo.py');
   const modelPath = path.join(__dirname, 'yolo11n.pt');
+  console.log('[+] Starting YOLO training...');
   run('python', [
     trainScript,
     '--data', dataYamlPath,
     '--model', modelPath,
   ]);
+  console.log('[+] Training completed.');
 }
 
 main();

--- a/split_dataset.py
+++ b/split_dataset.py
@@ -18,6 +18,7 @@ def split_dataset_three_way(
     - train_ratio + val_ratio <= 1.0
     - test_ratio is implied as (1 - train_ratio - val_ratio)
     """
+    print(f"[+] Splitting dataset: images={images_dir}, labels={labels_dir}, output={output_dir}")
     # 1) List all images
     IM_EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".tiff"}
     all_images = [

--- a/train_yolo.py
+++ b/train_yolo.py
@@ -18,8 +18,9 @@ def main() -> None:
     parser.add_argument("--project", default="models", help="Ultralytics project directory")
     parser.add_argument("--name", default="exp_ex_corr", help="Training run name")
     args = parser.parse_args()
-
+    print(f"[+] Loading model {args.model}")
     model = YOLO(args.model)
+    print("[+] Starting training...")
     model.train(
         data=args.data,
         epochs=args.epochs,
@@ -30,6 +31,7 @@ def main() -> None:
         name=args.name,
         tensorboard=True,
     )
+    print("[+] Training finished")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add console logging to mastermind orchestrator
- log S3 downloads and bucket scans
- log dataset splitting and model training stages

## Testing
- `node mastermind.py /tmp/workspace_test` *(fails: Unable to locate credentials)*
- `python split_dataset.py -i images -l labels -o dataset`
- `python train_yolo.py --data data.yaml --model yolo11n.pt` *(fails: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_e_689070e64cd0832d8addf729724487e1