### PR TITLE
Remove deprecated tensorboard flag

### DIFF
--- a/train_yolo.py
+++ b/train_yolo.py
@@ -29,7 +29,6 @@ def main() -> None:
         patience=args.patience,
         project=args.project,
         name=args.name,
-        tensorboard=True,
     )
     print("[+] Training finished")
 

--- a/train_yolo.sh
+++ b/train_yolo.sh
@@ -34,5 +34,4 @@ ultralytics train detect \
     batch=$BATCH \
     patience=$PATIENCE \
     project=$PROJECT_DIR \
-    name=$EXP_NAME \
-    tensorboard=True
+    name=$EXP_NAME


### PR DESCRIPTION
## Summary
- remove unsupported `tensorboard=True` parameter from training scripts

## Testing
- `python -m py_compile train_yolo.py`
- `bash -n train_yolo.sh`
- `python train_yolo.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689075ba22b4832da42926e129d866bb