### PR TITLE
feat: allow selecting training device

### DIFF
--- a/train_yolo.py
+++ b/train_yolo.py
@@ -17,6 +17,7 @@ def main() -> None:
     parser.add_argument("--patience", type=int, default=15, help="Early stopping patience")
     parser.add_argument("--project", default="models", help="Ultralytics project directory")
     parser.add_argument("--name", default="exp_ex_corr", help="Training run name")
+    parser.add_argument("--device", default="0", help="Device to train on, i.e. '0' or 'cpu'")
     args = parser.parse_args()
     print(f"[+] Loading model {args.model}")
     model = YOLO(args.model)
@@ -29,6 +30,7 @@ def main() -> None:
         patience=args.patience,
         project=args.project,
         name=args.name,
+        device=args.device,
     )
     print("[+] Training finished")
 

--- a/train_yolo.sh
+++ b/train_yolo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Train YOLOv8 model for document element detection.
-# Usage: ./train_yolo.sh [epochs] [batch_size] [imgsz] [model] [data_cfg] [project_dir] [exp_name]
+# Usage: ./train_yolo.sh [epochs] [batch_size] [imgsz] [model] [data_cfg] [project_dir] [exp_name] [device]
 
 EPOCHS=${1:-200}
 BATCH=${2:-16}
@@ -10,6 +10,7 @@ DATA_CFG=${5:-data.yaml}
 PROJECT_DIR=${6:-models}
 EXP_NAME=${7:-exp_ex_corr}
 PATIENCE=${8:-15}
+DEVICE=${9:-0}
 
 # If S3 buckets are provided, fetch images and labels then create dataset split
 if [ -n "$S3_BUCKETS" ]; then
@@ -34,4 +35,5 @@ ultralytics train detect \
     batch=$BATCH \
     patience=$PATIENCE \
     project=$PROJECT_DIR \
-    name=$EXP_NAME
+    name=$EXP_NAME \
+    device=$DEVICE


### PR DESCRIPTION
## Summary
- expose a `--device` flag in `train_yolo.py` to choose GPU or CPU
- add optional device parameter to `train_yolo.sh` and forward to Ultralytics

## Testing
- `python -m py_compile train_yolo.py`
- `bash -n train_yolo.sh`
- `python train_yolo.py --help` *(fails: No module named 'ultralytics')*


------
https://chatgpt.com/codex/tasks/task_e_689082322aa8832d8c1873477587bc92