### PR TITLE
Add installation support for YOLO pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# YOLO Pipeline
+
+Utilities and scripts for training a YOLOv8 model on custom datasets.
+
+## Installation
+
+```bash
+pip install .
+```
+
+This installs the following command line tools:
+
+- `fetch-s3-dataset` – download images and annotations from S3.
+- `split-dataset` – split images and labels into train/val/test sets.
+- `train-yolo` – train a YOLOv8 model using `ultralytics`.
+
+## Usage
+
+See `--help` for each command for detailed options.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yolo-pipeline"
+version = "0.1.0"
+description = "Utilities for training a YOLOv8 model and handling datasets"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "ultralytics>=8.0",
+    "torch>=1.8",
+    "boto3>=1.26"
+]
+
+[project.scripts]
+fetch-s3-dataset = "fetch_s3_dataset:main"
+split-dataset = "split_dataset:main"
+train-yolo = "train_yolo:main"
+
+[tool.setuptools]
+py-modules = ["fetch_s3_dataset", "split_dataset", "train_yolo"]


### PR DESCRIPTION
## Summary
- Package pipeline scripts with a `pyproject.toml` including dependencies and CLI entry points
- Provide installation instructions and command overview in new `README.md`

## Testing
- `pip install -e . --no-deps`
- `python -m py_compile fetch_s3_dataset.py split_dataset.py train_yolo.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a0eab550832d98dddec32b5265ae