### PR TITLE
Add installation support for YOLO pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# YOLO Pipeline
+
+Utilities and scripts for training a YOLOv8 model on custom datasets.
+
+## Installation
+
+```bash
+npm install
+```
+
+Running `npm install` triggers a `postinstall` script that installs the Python package and its dependencies via `pip`. It also exposes the following command line tools:
+
+- `fetch-s3-dataset` – download images and annotations from S3.
+- `split-dataset` – split images and labels into train/val/test sets.
+- `train-yolo` – train a YOLOv8 model using `ultralytics`.
+
+## Usage
+
+See `--help` for each command for detailed options.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "yolo-pipeline",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yolo-pipeline",
+      "version": "0.1.0",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "yolo-pipeline",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "pip install ."
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yolo-pipeline"
+version = "0.1.0"
+description = "Utilities for training a YOLOv8 model and handling datasets"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "ultralytics>=8.0",
+    "torch>=1.8",
+    "boto3>=1.26"
+]
+
+[project.scripts]
+fetch-s3-dataset = "fetch_s3_dataset:main"
+split-dataset = "split_dataset:main"
+train-yolo = "train_yolo:main"
+
+[tool.setuptools]
+py-modules = ["fetch_s3_dataset", "split_dataset", "train_yolo"]


### PR DESCRIPTION
## Summary
- Package pipeline scripts with a `pyproject.toml` including dependencies and CLI entry points
- Provide a `package.json` so `npm install` installs Python dependencies via a postinstall hook
- Document `npm install` usage and available commands in the README

## Testing
- `npm install --no-audit --no-fund`
- `python -m py_compile fetch_s3_dataset.py split_dataset.py train_yolo.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a0eab550832d98dddec32b5265ae